### PR TITLE
README example does not work with latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ with an elipsis '...':
 (asynchronize
   (def res (.get http "http://www.google.com" ...))
   (console/log res))
+  ;;; This example does not work now that the code assumes the callback is (fn [err res] ...)
 ```
 
 More examples can be found in [examples](https://github.com/gilbertw1/cljs-asynchronize/tree/master/examples)


### PR DESCRIPTION
Hi I think this example does not work now you have put the err channel in
